### PR TITLE
Fix C++ Modules Template Export Syntax

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
           version: ${{ matrix.clang }}
       - name: Install libc++
         if: ${{ matrix.stdlib == 'libc++' }}
-        run: sudo apt-get install -y libc++abi-${{ matrix.clang }}-dev libc++1-${{ matrix.clang }} libc++-${{ matrix.clang }}-dev
+        run: sudo apt-get install -y libc++abi-${{ matrix.clang }}-dev libc++-${{ matrix.clang }}-dev
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: c++ -v

--- a/include/ipaddress/byte-array.hpp
+++ b/include/ipaddress/byte-array.hpp
@@ -258,7 +258,7 @@ struct byte_array {
     }
 }; // byte_array<N>
 
-IPADDRESS_EXPORT template <>
+template <>
 class byte_array<0> {
 public:
     using value_type      = uint8_t;

--- a/include/ipaddress/fixed-string.hpp
+++ b/include/ipaddress/fixed-string.hpp
@@ -376,7 +376,7 @@ struct fixed_string {
     }
 }; // fixed_string<N>
 
-IPADDRESS_EXPORT template <>
+template <>
 struct fixed_string<0> {
     using value_type             = char;
     using const_pointer          = const char*;

--- a/include/ipaddress/fixed-vector.hpp
+++ b/include/ipaddress/fixed-vector.hpp
@@ -1038,7 +1038,7 @@
      size_type _size{};
  }; // fixed_vector
  
- IPADDRESS_EXPORT template <typename T>
+ template <typename T>
  class fixed_vector<T, 0> {
  public:
      using value_type             = T;

--- a/include/ipaddress/ip-address-base.hpp
+++ b/include/ipaddress/ip-address-base.hpp
@@ -831,7 +831,7 @@ IPADDRESS_FORCE_INLINE std::basic_ostream<T, std::char_traits<T>>& compressed(st
 
 namespace std {
 
-IPADDRESS_EXPORT template <typename Base>
+template <typename Base>
 struct hash<IPADDRESS_NAMESPACE::ip_address_base<Base>> {
     IPADDRESS_NODISCARD IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE size_t operator()(const IPADDRESS_NAMESPACE::ip_address_base<Base>& ip) const IPADDRESS_NOEXCEPT {
         return ip.hash();

--- a/include/ipaddress/ip-address-iterator.hpp
+++ b/include/ipaddress/ip-address-iterator.hpp
@@ -415,7 +415,7 @@ class ip_address_iterator;
  * 
  * @tparam Base The base type from which the ip_address_base is derived, representing the underlying IP address type.
  */
-IPADDRESS_EXPORT template <typename Base>
+template <typename Base>
 class ip_address_iterator<ip_address_base<Base>> {
 public:
     using iterator_category = std::random_access_iterator_tag; /**< The category of the iterator. */
@@ -858,7 +858,7 @@ class hosts_sequence;
  * @tparam Base The base type from which the ip_address_base is derived, representing the underlying IP address type.
  * @remark When iterating, obtaining addresses occurs through lazy calculations.
  */
-IPADDRESS_EXPORT template <typename Base>
+template <typename Base>
 class hosts_sequence<ip_address_base<Base>> {
 public:
     using value_type      = ip_address_base<Base>; /**< The type of the IP addresses in the sequence. */

--- a/include/ipaddress/ip-any-address.hpp
+++ b/include/ipaddress/ip-any-address.hpp
@@ -1530,7 +1530,7 @@ private:
 
 namespace std {
 
-IPADDRESS_EXPORT template <>
+template <>
 struct hash<IPADDRESS_NAMESPACE::ip_address> {
     IPADDRESS_NODISCARD IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE size_t operator()(const IPADDRESS_NAMESPACE::ip_address& ip) const IPADDRESS_NOEXCEPT {
         return ip.hash();

--- a/include/ipaddress/ip-any-network.hpp
+++ b/include/ipaddress/ip-any-network.hpp
@@ -1441,7 +1441,7 @@ private:
 
 namespace std {
 
-IPADDRESS_EXPORT template <>
+template <>
 struct hash<IPADDRESS_NAMESPACE::ip_network> {
     IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE size_t operator()(const IPADDRESS_NAMESPACE::ip_network& network) const IPADDRESS_NOEXCEPT {
         return network.hash();

--- a/include/ipaddress/ip-network-base.hpp
+++ b/include/ipaddress/ip-network-base.hpp
@@ -1367,7 +1367,7 @@ IPADDRESS_FORCE_INLINE std::basic_istream<T, std::char_traits<T>>& non_strict(st
 
 namespace std {
 
-IPADDRESS_EXPORT template <typename Base>
+template <typename Base>
 struct hash<IPADDRESS_NAMESPACE::ip_network_base<Base>> {
     IPADDRESS_NODISCARD IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE size_t operator()(const IPADDRESS_NAMESPACE::ip_network_base<Base>& network) const IPADDRESS_NOEXCEPT {
         return network.hash();

--- a/include/ipaddress/uint128.hpp
+++ b/include/ipaddress/uint128.hpp
@@ -1901,7 +1901,9 @@ namespace std {
   _Pragma("clang diagnostic ignored \"-Wdeprecated\"")
 #endif
 
-template <typename T>
+#if IPADDRESS_CPP_VERSION < 14
+template <typename>
+#endif
 struct _numeric_limits_uint128 {
     static constexpr bool is_bounded                    = true;
     static constexpr bool is_exact                      = true;
@@ -1926,43 +1928,9 @@ struct _numeric_limits_uint128 {
     static constexpr int radix                          = 2;
     static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
     static constexpr std::float_round_style round_style = std::round_toward_zero;
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T (min)() IPADDRESS_NOEXCEPT {
-        return 0;
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T (max)() IPADDRESS_NOEXCEPT {
-        return T(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T lowest() IPADDRESS_NOEXCEPT {
-        return (min)();
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T epsilon() IPADDRESS_NOEXCEPT {
-        return 0;
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T round_error() IPADDRESS_NOEXCEPT {
-        return 0;
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T denorm_min() IPADDRESS_NOEXCEPT {
-        return 0;
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T infinity() IPADDRESS_NOEXCEPT {
-        return 0;
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T quiet_NaN() IPADDRESS_NOEXCEPT {
-        return 0;
-    }
-
-    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE T signaling_NaN() IPADDRESS_NOEXCEPT {
-        return 0;
-    }
 };
+
+#if IPADDRESS_CPP_VERSION < 14
 
 template <typename T>
 constexpr bool _numeric_limits_uint128<T>::is_bounded;
@@ -2033,6 +2001,8 @@ constexpr std::float_denorm_style _numeric_limits_uint128<T>::has_denorm;
 template <typename T>
 constexpr std::float_round_style _numeric_limits_uint128<T>::round_style;
 
+#endif // IPADDRESS_CPP_VERSION < 14
+
 #if defined(_MSC_VER)
 #  pragma warning(default:4996)
 #elif defined(__GNUC__)
@@ -2042,11 +2012,50 @@ constexpr std::float_round_style _numeric_limits_uint128<T>::round_style;
 #endif
 #pragma warning(pop)
 
-IPADDRESS_EXPORT template <>
-struct numeric_limits<IPADDRESS_NAMESPACE::uint128_t> : _numeric_limits_uint128<IPADDRESS_NAMESPACE::uint128_t> {
+template <>
+struct numeric_limits<IPADDRESS_NAMESPACE::uint128_t> : _numeric_limits_uint128
+#if IPADDRESS_CPP_VERSION < 14
+    <IPADDRESS_NAMESPACE::uint128_t>
+#endif
+{
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t (min)() IPADDRESS_NOEXCEPT {
+        return 0;
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t (max)() IPADDRESS_NOEXCEPT {
+        return IPADDRESS_NAMESPACE::uint128_t(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t lowest() IPADDRESS_NOEXCEPT {
+        return (min)();
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t epsilon() IPADDRESS_NOEXCEPT {
+        return 0;
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t round_error() IPADDRESS_NOEXCEPT {
+        return 0;
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t denorm_min() IPADDRESS_NOEXCEPT {
+        return 0;
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t infinity() IPADDRESS_NOEXCEPT {
+        return 0;
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t quiet_NaN() IPADDRESS_NOEXCEPT {
+        return 0;
+    }
+
+    IPADDRESS_NODISCARD static IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE IPADDRESS_NAMESPACE::uint128_t signaling_NaN() IPADDRESS_NOEXCEPT {
+        return 0;
+    }
 };
 
-IPADDRESS_EXPORT template <>
+template <>
 struct hash<IPADDRESS_NAMESPACE::uint128_t> {
     IPADDRESS_NODISCARD IPADDRESS_CONSTEXPR IPADDRESS_FORCE_INLINE size_t operator()(const IPADDRESS_NAMESPACE::uint128_t& value) const IPADDRESS_NOEXCEPT {
         return value.hash();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,11 @@ add_executable(ipaddress-tests
   "ip-network-tests.cpp")
 target_link_libraries(ipaddress-tests PRIVATE GTest::gtest GTest::gtest_main GTest::gmock_main)
 if(IPADDRESS_TEST_MODULE)
+  if(NOT CMAKE_CXX_STANDARD)
+    message(FATAL_ERROR
+      "CMAKE_CXX_STANDARD must be explicitly set when building tests with C++ modules.\n"
+      "For example: -DCMAKE_CXX_STANDARD=20")
+  endif()
   target_link_libraries(ipaddress-tests PRIVATE ipaddress-module)
   set_target_properties(ipaddress-tests PROPERTIES CXX_SCAN_FOR_MODULES ON)
   set_target_properties(ipaddress-tests PROPERTIES CXX_EXTENSIONS OFF)


### PR DESCRIPTION
## Summary
Fix C++ modules compilation with GCC 15.2 by correcting template export syntax.

## Changes
- Remove explicit `IPADDRESS_EXPORT` from template specializations  
- Specializations now inherit export automatically per C++ standard

## Standards Compliance
Fixes comply with C++ standard §10.2 [module.interface] rules for template specialization exports
